### PR TITLE
Add support for Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     ],
     "require": {
         "php": "^8.1",
-        "laravel/framework": "^10.0|^11.0"
+        "laravel/framework": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13",
-        "orchestra/testbench": "^8.0"
+        "orchestra/testbench": "^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi, I've added support for Laravel 12, which was released this week. 

I also updated the `orchestra/testbench` versions, for Laravel major version compatibility.

Note that to make the tests pass, even before I changed anything, I had to make `$isp` nullable in `src/ResponseObjects/CheckResponse.php`:
```
-    public string $isp;
+    public ?string $isp;
```
This was throwing an exception because the tests use loopback IPs, so it makes sense for the API to return `null` for the ISP for those. Since it's unrelated to the Laravel version, I left it out of this PR. But if there's any possibility of the API returning `null` for a valid public IP's ISP, then that should be a permanent change. Otherwise, IMO a different approach would be better, like mocking the API for the tests.