### PR TITLE
[1.x] Fixes return types for methods on Facade's PHPDocs and deprecated parameter warning

### DIFF
--- a/src/Facades/AbuseIPDB.php
+++ b/src/Facades/AbuseIPDB.php
@@ -3,6 +3,14 @@
 namespace AbuseIPDB\Facades;
 
 use AbuseIPDB\AbuseIPDBLaravel;
+use AbuseIPDB\ResponseObjects\BlacklistPlaintextResponse;
+use AbuseIPDB\ResponseObjects\BlacklistResponse;
+use AbuseIPDB\ResponseObjects\BulkReportResponse;
+use AbuseIPDB\ResponseObjects\CheckBlockResponse;
+use AbuseIPDB\ResponseObjects\CheckResponse;
+use AbuseIPDB\ResponseObjects\ClearAddressResponse;
+use AbuseIPDB\ResponseObjects\ReportResponse;
+use AbuseIPDB\ResponseObjects\ReportsPaginatedResponse;
 use Datetime;
 use Illuminate\Support\Facades\Facade;
 
@@ -19,7 +27,7 @@ use Illuminate\Support\Facades\Facade;
  */
 class AbuseIPDB extends Facade
 {
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return AbuseIPDBLaravel::class;
     }

--- a/src/ResponseObjects/CheckResponse.php
+++ b/src/ResponseObjects/CheckResponse.php
@@ -4,6 +4,7 @@ namespace AbuseIPDB\ResponseObjects;
 
 use AbuseIPDB\ResponseObjects\ExtraClasses\ReportInfo;
 use DateTime;
+use DateTimeInterface;
 use Illuminate\Http\Client\Response;
 
 class CheckResponse extends AbuseResponse
@@ -64,8 +65,9 @@ class CheckResponse extends AbuseResponse
         $this->numDistinctUsers = $data->numDistinctUsers;
         $this->countryName = $data->countryName ?? null;
 
-        $lastReportedAtParsed = DateTime::createFromFormat(DateTime::ATOM, $data->lastReportedAt);
-        $this->lastReportedAt = $lastReportedAtParsed ?: null;
+        $this->lastReportedAt = isset($data->lastReportedAt)
+            ? DateTime::createFromFormat(DateTimeInterface::ATOM, $data->lastReportedAt)
+            : null;
 
         $this->reports = [];
         if (isset($data->reports)) {


### PR DESCRIPTION
This pull request adds the imports used on Facade's PHPDocs, fixing IDE autocomplete and static analysis errors like below.

```
------ -------------------------------------------------------------------------------------------------------------- 
  Line   Facades/AbuseIPDB.php                                                                                         
 ------ -------------------------------------------------------------------------------------------------------------- 
  20     PHPDoc tag @method for method AbuseIPDB\Facades\AbuseIPDB::blacklist() return type contains unknown class     
         AbuseIPDB\Facades\BlacklistPlaintextResponse.                                                                 
         🪪  class.notFound                                                                                            
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols                                          
  20     PHPDoc tag @method for method AbuseIPDB\Facades\AbuseIPDB::blacklist() return type contains unknown class     
         AbuseIPDB\Facades\BlacklistResponse.                                                                          
         🪪  class.notFound                                                                                            
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols                                          
  20     PHPDoc tag @method for method AbuseIPDB\Facades\AbuseIPDB::bulkReport() return type contains unknown class    
         AbuseIPDB\Facades\BulkReportResponse.                                                                         
         🪪  class.notFound                                                                                            
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols                                          
  20     PHPDoc tag @method for method AbuseIPDB\Facades\AbuseIPDB::check() return type contains unknown class         
         AbuseIPDB\Facades\CheckResponse.                                                                              
         🪪  class.notFound                                                                                            
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols                                          
  20     PHPDoc tag @method for method AbuseIPDB\Facades\AbuseIPDB::checkBlock() return type contains unknown class    
         AbuseIPDB\Facades\CheckBlockResponse.                                                                         
         🪪  class.notFound                                                                                            
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols                                          
  20     PHPDoc tag @method for method AbuseIPDB\Facades\AbuseIPDB::clearAddress() return type contains unknown class  
         AbuseIPDB\Facades\ClearAddressResponse.                                                                       
         🪪  class.notFound                                                                                            
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols                                          
  20     PHPDoc tag @method for method AbuseIPDB\Facades\AbuseIPDB::report() return type contains unknown class        
         AbuseIPDB\Facades\ReportResponse.                                                                             
         🪪  class.notFound                                                                                            
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols                                          
  20     PHPDoc tag @method for method AbuseIPDB\Facades\AbuseIPDB::reports() return type contains unknown class       
         AbuseIPDB\Facades\ReportsPaginatedResponse.                                                                   
         🪪  class.notFound                                                                                            
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols                                          
 ------ --------------------------------------------------------------------------------------------------------------
```

Also, this pull request adds a check if the content of the  response's property `lastReportedAt` is null before parsing it as a `DateTime` object, avoiding deprecated parameter warnings such as:

```
DateTime::createFromFormat(): Passing null to parameter #2 ($datetime) of type string is deprecated in /var/www/app/vendor/abuseipdb/laravel/src/ResponseObjects/CheckResponse.php on line 67
```